### PR TITLE
Update from Node 6 to Node 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.11-slim
+FROM node:8-slim
 
 # grab tini for signal processing and zombie killing
 ENV TINI_VERSION 0.9.0


### PR DESCRIPTION
Node 8 is the latest LTS (starting 2017-10-31 and likely ending December 2019); see https://github.com/nodejs/Release.

I figured I'd send this one separate from https://github.com/mongo-express/mongo-express-docker/pull/7 since it's probably not quite as much of a complete no-brainer to merge (although maybe I'm wrong and it is :smile:).  I couldn't find anything in https://github.com/mongo-express/mongo-express about recommended or even supported versions of Node.js, but I can't imagine the Node.js 8 LTS is a big problem?  If it is, I'd be happy to simply update this to `node:6-slim` (instead of `6.11` explicitly) so that it can automatically get the LTS base image updates. :+1: :heart: