### PR TITLE
Add ARM64 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-slim
+FROM node:8-stretch
 
 # grab tini for signal processing and zombie killing
 ENV TINI_VERSION 0.18.0


### PR DESCRIPTION
This **PR** has been raised followed by the discussion on #15 .

The changes are verified both on ```amd64``` & ```arm64v8``` architectures.

I can also provide build & run logs as required for confirmation.
It would be great to see ```arm64v8``` in the list of officially supported platforms by ```mongo-express```.

Regards,