### PR TITLE
Switch to Alpine, simplifying the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,6 @@
-FROM node:8-slim
+FROM node:8-alpine
 
-# grab tini for signal processing and zombie killing
-ENV TINI_VERSION 0.18.0
-RUN set -x \
-	&& apt-get update && apt-get install -y ca-certificates curl \
-		--no-install-recommends \
-	&& dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
-	&& curl -fSL "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-$dpkgArch" -o /usr/local/bin/tini \
-	&& curl -fSL "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-$dpkgArch.asc" -o /usr/local/bin/tini.asc \
-	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 6380DC428747F6C393FEACA59A84159D7001A4E5 \
-	&& gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini \
-	&& rm -r "$GNUPGHOME" /usr/local/bin/tini.asc \
-	&& chmod +x /usr/local/bin/tini \
-	&& tini -h \
-	&& apt-get purge --auto-remove -y ca-certificates curl \
-	&& rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache bash tini
 
 EXPOSE 8081
 


### PR DESCRIPTION
This also makes it possible to support more architectures like arm64v8! :tada:

Closes #15
Closes #17

As noted in https://github.com/mongo-express/mongo-express-docker/pull/17#issuecomment-415848289, this takes the image from ~200MB down to ~100MB with no apparent functionality loss. :muscle: