### PR TITLE
Add support for docker secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ JSON documents are parsed through a javascript virtual machine, so the web inter
 
 # Configuration
 
-Environment vairables are passed to the `run` command for configuring a mongo-express container.
+Environment variables are passed to the `run` command for configuring a mongo-express container.
 
 	Name                            | Default         | Description
 	--------------------------------|-----------------|------------

--- a/README.md
+++ b/README.md
@@ -62,3 +62,30 @@ The following are only needed if `ME_CONFIG_MONGODB_ENABLE_ADMIN` is **"false"**
 		mongo-express
 
 This example links to a container name typical of `docker-compose`, changes the editor's color theme, and enables basic authentication.
+
+# Docker secrets
+
+As an alternative to passing sensitive information via environment variables \_FILE may be appended to  username and password environment variables, causing the initialization script to load the values for those variables from files present in the container. In particular, this can be used to load passwords from Docker secrets stored in /run/secrets/<secret_name> files.
+
+## Example
+```
+version: '3.5'
+services:
+  mongo-express:
+    image: mongo-express:latest
+    ports:
+      - 8081:8081
+    environment:
+      ME_CONFIG_MONGODB_ADMINUSERNAME: root
+      ME_CONFIG_MONGODB_ADMINPASSWORD_FILE: /run/secrets/mongo_root_pass
+      ME_CONFIG_BASICAUTH_USERNAME: admin
+      ME_CONFIG_BASICAUTH_PASSWORD_FILE: /run/secrets/mongo_express_admin_pass
+    secrets:
+      - mongo_root_pass
+      - mongo_express_admin_pass
+secrets:
+  mongo_root_pass:
+    external: true
+  mongo_express_admin_pass:
+    external: true
+```

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -19,6 +19,41 @@ function wait_tcp_port {
     exec 6>&-
 }
 
+# from https://github.com/docker-library/mongo/blob/master/4.1/docker-entrypoint.sh
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+    local var="$1"
+    local fileVar="${var}_FILE"
+    local def="${2:-}"
+
+    if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+        echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+        exit 1
+    fi
+
+    local val="$def"
+
+    if [ "${!var:-}" ]; then
+        val="${!var}"
+    elif [ "${!fileVar:-}" ]; then
+        val="$(< "${!fileVar}")"
+    fi
+
+    export "$var"="$val"
+    unset "$fileVar"
+}
+
+# set env variables to content of the following {VAR}_FILE env variables
+file_env 'ME_CONFIG_BASICAUTH_USERNAME'
+file_env 'ME_CONFIG_BASICAUTH_PASSWORD'
+file_env 'ME_CONFIG_MONGODB_ADMINUSERNAME'
+file_env 'ME_CONFIG_MONGODB_ADMINPASSWORD'
+file_env 'ME_CONFIG_SITE_COOKIESECRET'
+file_env 'ME_CONFIG_SITE_SESSIONSECRET'
+
 # wait for the mongo server to be available
 echo Waiting for ${ME_CONFIG_MONGODB_SERVER}:${ME_CONFIG_MONGODB_PORT:-27017}...
 wait_tcp_port "${ME_CONFIG_MONGODB_SERVER}" "${ME_CONFIG_MONGODB_PORT:-27017}"


### PR DESCRIPTION
The mongo docker image uses the VAR_FILE convention to load sensitive content from files. This uses the function from https://github.com/docker-library/mongo/blob/master/4.1/docker-entrypoint.sh to achieve the same.