### PR TITLE
Improve Dockerfile and add try in PWD button

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ mongo-express is a web-based MongoDB admin interface written in Node.js, Express
 
 # How to use this image
 
+[![Try in PWD](https://raw.githubusercontent.com/play-with-docker/stacks/master/assets/images/button.png)](https://labs.play-with-docker.com/?stack=https://raw.githubusercontent.com/mongo-express/mongo-express-docker/master/docker-compose.yml)
+
 ```console
 $ docker run --link some_mongo_container:mongo -p 8081:8081 mongo-express
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,21 @@
-mongo:
-    image: mongo
+version: '3.4'
 
-mongoexpress:
-    image: mongo-express-docker
-    ports:
-        - "8081:8081"
-    links:
-        - mongo
+services:
+    mongo:
+        image: mongo:4
+        networks:
+            backend:
+        restart: always
+
+    mongoexpress:
+        image: mongo-express
+        ports:
+            - "8081:8081"
+        depends_on:
+          - mongo
+        restart: always
+        networks:
+            backend:
+
+networks:
+    backend:


### PR DESCRIPTION
Thill pull will add an Try in PWD button. This makes it easy to deploy the stack to play-with-docker.com for testing.

Notice: The button does not work right now, because the link to the compose file is not valid before merge.

If you want to try this out, use this link: https://labs.play-with-docker.com/?stack=https://raw.githubusercontent.com/david-kroell/mongo-express-docker/master/docker-compose.yml
