### PR TITLE
Update to Node.js 12 (8 is EOL, 12 is LTS)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM node:8-alpine
+# https://nodejs.org/en/about/releases/
+# https://github.com/nodejs/Release#readme
+FROM node:12-alpine3.11
 
 RUN apk add --no-cache bash tini
 
@@ -14,7 +16,10 @@ ENV ME_CONFIG_EDITORTHEME="default" \
 
 ENV MONGO_EXPRESS 0.51.0
 
-RUN npm install mongo-express@$MONGO_EXPRESS
+RUN set -eux; \
+	apk add --no-cache --virtual .me-install-deps git; \
+	npm install mongo-express@$MONGO_EXPRESS; \
+	apk del --no-network .me-install-deps
 
 COPY docker-entrypoint.sh /
 

--- a/update.sh
+++ b/update.sh
@@ -1,11 +1,9 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
+set -Eeuo pipefail
 
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
-nodeVersion="$(awk '$1 == "FROM" { print $2; exit }' Dockerfile)"
-
-mongoExpressVersion="$(docker run --rm "$nodeVersion" npm show mongo-express version)"
+mongoExpressVersion="$(wget -qO- 'https://registry.npmjs.org/mongo-express' | jq -r '."dist-tags".latest')"
 
 echo "$mongoExpressVersion"
 


### PR DESCRIPTION
Also, this updates `update.sh` to no longer use Docker and instead query "registry.npmjs.org" directly (which is much faster).

I did *not* update the actual version number here since I'd like to make sure I've got something to test @docker-library-bot integration with. :sweat_smile:

I *did* however test this against https://github.com/docker-library/official-images/pull/5697 successfully. :+1:

(Without this, `./generate-stackbrew-library.sh` fails because `node:8-alpine` isn't supported anymore.)