### PR TITLE
Add inital "generate-stackbrew-library.sh" script

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+self="$(basename "$BASH_SOURCE")"
+cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+commit="$(git log -1 --format='format:%H')"
+cat <<-EOH
+# this file is generated via https://github.com/mongo-express/mongo-express-docker/blob/$commit/$self
+
+Maintainers: Nick Cox <nickcox1008@gmail.com> (@knickers)
+GitRepo: https://github.com/mongo-express/mongo-express-docker.git
+GitCommit: $commit
+EOH
+
+# prints "$2$1$3$1...$N"
+join() {
+	local sep="$1"; shift
+	local out; printf -v out "${sep//%/%%}%s" "$@"
+	echo "${out#$sep}"
+}
+
+fullVersion="$(awk '$1 == "ENV" && $2 == "MONGO_EXPRESS" { print $3; exit }' Dockerfile)"
+
+versionAliases=()
+while [ "${fullVersion%.*}" != "$fullVersion" ]; do
+	versionAliases+=( $fullVersion )
+	fullVersion="${fullVersion%.*}"
+done
+versionAliases+=(
+	latest
+)
+
+echo
+cat <<-EOE
+	Tags: $(join ', ' "${versionAliases[@]}")
+	Architectures: amd64, arm64v8
+EOE


### PR DESCRIPTION
This is intended to be run to generate the contents of https://github.com/docker-library/official-images/blob/master/library/mongo-express.

(As mentioned in https://github.com/mongo-express/mongo-express-docker/pull/40#issuecomment-580989077)

Example output:

```console
$ ./generate-stackbrew-library.sh
# this file is generated via https://github.com/mongo-express/mongo-express-docker/blob/2abe17be545f43d50c17a188ac781174a7ea3e9d/generate-stackbrew-library.sh

Maintainers: Nick Cox <nickcox1008@gmail.com> (@knickers)
GitRepo: https://github.com/mongo-express/mongo-express-docker.git
GitCommit: 2abe17be545f43d50c17a188ac781174a7ea3e9d

Tags: 0.51.0, 0.51, latest
Architectures: amd64, arm64v8
```

```diff
$ diff -u <(bashbrew cat mongo-express) <(bashbrew cat <(./generate-stackbrew-library.sh))
--- /dev/fd/63	2020-01-31 20:22:39.646681867 -0800
+++ /dev/fd/62	2020-01-31 20:22:39.646681867 -0800
@@ -1,6 +1,6 @@
 Maintainers: Nick Cox <nickcox1008@gmail.com> (@knickers)
+GitRepo: https://github.com/mongo-express/mongo-express-docker.git
+GitCommit: 2abe17be545f43d50c17a188ac781174a7ea3e9d
 
-Tags: 0.49.0, 0.49, latest
+Tags: 0.51.0, 0.51, latest
 Architectures: amd64, arm64v8
-GitRepo: https://github.com/mongo-express/mongo-express-docker.git
-GitCommit: b089fe7708d9dd619d648a6ec226fe0175b27740
```