### PR TITLE
Parameterize connection attempt retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Environment vairables are passed to the `run` command for configuring a mongo-ex
 	--------------------------------|-----------------|------------
 	ME_CONFIG_BASICAUTH_USERNAME    | ''              | mongo-express web username
 	ME_CONFIG_BASICAUTH_PASSWORD    | ''              | mongo-express web password
+	ME_CONFIG_CONNECT_RETRIES       | 5               | Number of startup connection retry attempts to be made
 	ME_CONFIG_MONGODB_ENABLE_ADMIN  | 'true'          | Enable admin access to all databases. Send strings: `"true"` or `"false"`
 	ME_CONFIG_MONGODB_ADMINUSERNAME | ''              | MongoDB admin username
 	ME_CONFIG_MONGODB_ADMINPASSWORD | ''              | MongoDB admin password

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,7 +8,7 @@ fi
 
 function wait_tcp_port {
     local host="$1" port="$2"
-    local max_tries=5 tries=1
+    local max_tries="$3" tries=1
 
     # see http://tldp.org/LDP/abs/html/devref1.html for description of this syntax.
     while ! exec 6<>/dev/tcp/$host/$port && [[ $tries -lt $max_tries ]]; do
@@ -23,7 +23,7 @@ function wait_tcp_port {
 if [[ "$ME_CONFIG_MONGODB_SERVER" != *,* ]]; then
 	# wait for the mongo server to be available
 	echo Waiting for ${ME_CONFIG_MONGODB_SERVER}:${ME_CONFIG_MONGODB_PORT:-27017}...
-	wait_tcp_port "${ME_CONFIG_MONGODB_SERVER}" "${ME_CONFIG_MONGODB_PORT:-27017}"
+	wait_tcp_port "${ME_CONFIG_MONGODB_SERVER}" "${ME_CONFIG_MONGODB_PORT:-27017}" "${ME_CONFIG_CONNECT_RETRIES:-5}"
 fi
 
 # run mongo-express


### PR DESCRIPTION
Sometimes it takes longer than 5 seconds for the MongoDB instance to come up. This seems to be the case on my 2015 Macbook when creating a fresh instance. 

This pull request changes the `max_retries` from a preset int to a variable that defaults to 5 so that users can choose to allow a longer connection retry sequence. It also adds the variable name to the README.

Thank you for your consideration!