### PR TITLE
entrypoint: don't wait for server if variable is not set

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -20,7 +20,7 @@ function wait_tcp_port {
 }
 
 # if ME_CONFIG_MONGODB_SERVER has a comma in it, we're pointing to a replica set (https://github.com/mongo-express/mongo-express-docker/issues/21)
-if [[ "$ME_CONFIG_MONGODB_SERVER" != *,* ]]; then
+if [[ -n "$ME_CONFIG_MONGODB_SERVER" ]] && [[ "$ME_CONFIG_MONGODB_SERVER" != *,* ]]; then
 	# wait for the mongo server to be available
 	echo Waiting for ${ME_CONFIG_MONGODB_SERVER}:${ME_CONFIG_MONGODB_PORT:-27017}...
 	wait_tcp_port "${ME_CONFIG_MONGODB_SERVER}" "${ME_CONFIG_MONGODB_PORT:-27017}"


### PR DESCRIPTION
When connecting to mongodb cloud atlas, I need to use ME_CONFIG_MONGODB_URL and ME_CONFIG_MONGODB_SERVER needs to be either pingable (thus creating duplicate config) or empty. When ME_CONFIG_MONGODB_SERVER is empty, the entrypoint script tries to connect to an empty string for 5 seconds...