### PR TITLE
Enabling Docker developers to pass a parameter to control max_tries 

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
 
-docker build -t mongo-express-docker .
+docker build -t taboca-mongo-express-docker .

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,7 +8,7 @@ fi
 
 function wait_tcp_port {
     local host="$1" port="$2"
-    local max_tries=5 tries=1
+    local max_tries=${ME_CONFIG_MONGODB_SERVER_WAIT_MAX_TRIES:-10} tries=1
 
     # see http://tldp.org/LDP/abs/html/devref1.html for description of this syntax.
     while ! exec 6<>/dev/tcp/$host/$port && [[ $tries -lt $max_tries ]]; do


### PR DESCRIPTION
I have described the problem here https://github.com/mongo-express/mongo-express-docker/issues/52

Let me know if you can help me here since I am not a contributor to open source projects nowadays. 