### PR TITLE
Enabling Docker developers to pass a parameter to control max_tries 

### DIFF
--- a/1.0/18-alpine3.18/docker-entrypoint.sh
+++ b/1.0/18-alpine3.18/docker-entrypoint.sh
@@ -41,7 +41,7 @@ if [[ "$ME_CONFIG_MONGODB_URL" != *,* ]]; then
 
     # wait for the mongo server to be available
     echo "Waiting for $host:$port..."
-    wait_tcp_port "$host" "$port"
+    wait_tcp_port "$host" "$port" "${ME_CONFIG_CONNECT_RETRIES:-10}"
 fi
 
 # run mongo-express

--- a/1.0/18-alpine3.19/docker-entrypoint.sh
+++ b/1.0/18-alpine3.19/docker-entrypoint.sh
@@ -41,7 +41,7 @@ if [[ "$ME_CONFIG_MONGODB_URL" != *,* ]]; then
 
     # wait for the mongo server to be available
     echo "Waiting for $host:$port..."
-    wait_tcp_port "$host" "$port"
+    wait_tcp_port "$host" "$port" "${ME_CONFIG_CONNECT_RETRIES:-10}"
 fi
 
 # run mongo-express

--- a/1.0/20-alpine3.18/docker-entrypoint.sh
+++ b/1.0/20-alpine3.18/docker-entrypoint.sh
@@ -41,7 +41,7 @@ if [[ "$ME_CONFIG_MONGODB_URL" != *,* ]]; then
 
     # wait for the mongo server to be available
     echo "Waiting for $host:$port..."
-    wait_tcp_port "$host" "$port"
+    wait_tcp_port "$host" "$port" "${ME_CONFIG_CONNECT_RETRIES:-10}"
 fi
 
 # run mongo-express

--- a/1.0/20-alpine3.19/docker-entrypoint.sh
+++ b/1.0/20-alpine3.19/docker-entrypoint.sh
@@ -41,7 +41,7 @@ if [[ "$ME_CONFIG_MONGODB_URL" != *,* ]]; then
 
     # wait for the mongo server to be available
     echo "Waiting for $host:$port..."
-    wait_tcp_port "$host" "$port"
+    wait_tcp_port "$host" "$port" "${ME_CONFIG_CONNECT_RETRIES:-10}"
 fi
 
 # run mongo-express

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Name | Default | Description
 `ME_CONFIG_MONGODB_URL` | `mongodb://mongo:27017` | MongoDB connection string
 `ME_CONFIG_BASICAUTH_USERNAME` | | mongo-express web username
 `ME_CONFIG_BASICAUTH_PASSWORD` | | mongo-express web password
-`ME_CONFIG_CONNECT_RETRIES` | `5` | Number of startup connection retry attempts to be made
+`ME_CONFIG_CONNECT_RETRIES` | `10` | Number of startup connection retry attempts to be made
 `ME_CONFIG_MONGODB_ENABLE_ADMIN` | `true` | Enable admin access to all databases. Send strings: `"true"` or `"false"`
 `ME_CONFIG_OPTIONS_EDITORTHEME` | `default` | mongo-express editor color theme, [more here](http://codemirror.net/demo/theme.html)
 `ME_CONFIG_REQUEST_SIZE` | `100kb` | Maximum payload size. CRUD operations above this size will fail in [body-parser](https://www.npmjs.com/package/body-parser).

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -40,7 +40,7 @@ if [[ "$ME_CONFIG_MONGODB_URL" != *,* ]]; then
 
     # wait for the mongo server to be available
     echo "Waiting for $host:$port..."
-    wait_tcp_port "$host" "$port"
+    wait_tcp_port "$host" "$port" "${ME_CONFIG_CONNECT_RETRIES:-10}"
 fi
 
 # run mongo-express


### PR DESCRIPTION
Fix #52

I believe that a lot of developers are having this issue but they think it's always something else. This problem may occur in slower machines like my MacAir i5 2013.  