### PR TITLE
Update to alpine 3.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # https://nodejs.org/en/about/releases/
 # https://github.com/nodejs/Release#readme
-FROM node:12-alpine3.11
+FROM node:12-alpine3.15
 
 RUN apk add --no-cache bash tini
 


### PR DESCRIPTION
There are many security updates we are missing out on (including zlib CVE-2018-25032)
by using the EOL alpine 3.11. This change updates to Alpine 3.15.