### PR TITLE
Update to node 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # https://nodejs.org/en/about/releases/
 # https://github.com/nodejs/Release#readme
-FROM node:12-alpine3.15
+FROM node:18-alpine3.15
 
 RUN apk add --no-cache bash tini
 


### PR DESCRIPTION
Node 18 will be supported when this MR is merged:
https://github.com/mongo-express/mongo-express/pull/851

So after that, we should update the docker image to use node 18.
