### PR TITLE
Bring in tzdata so users could set the timezones through the environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # https://github.com/nodejs/Release#readme
 FROM node:12-alpine3.15
 
-RUN apk add --no-cache bash tini
+RUN apk add --no-cache bash tini tzdata
 
 EXPOSE 8081
 


### PR DESCRIPTION
@tianon  Same reasons [#565](https://github.com/docker-library/rabbitmq/pull/565)

Supports using the TZ environment variable to set the timezone instead of using the volume bindings: /etc/timezone:/etc/timezone and /etc/localtime:/etc/localtime.