### PR TITLE
Change RUN command to use yarn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,29 +2,24 @@
 # https://github.com/nodejs/Release#readme
 FROM node:18-alpine3.16
 
-WORKDIR /app
-
 # override some config defaults with values that will work better for docker
 ENV ME_CONFIG_MONGODB_URL="mongodb://mongo:27017" \
     ME_CONFIG_MONGODB_ENABLE_ADMIN="true" \
     VCAP_APP_HOST="0.0.0.0"
 
-ARG MONGO_REPOSITORY=mongo-express/mongo-express
-ARG MONGO_EXPRESS_TAG=v1.0.0
+ARG MONGO_EXPRESS_VERSION=1.0.0
 
 COPY docker-entrypoint.sh /
 
 RUN set -eux; \
-    wget -c https://github.com/${MONGO_REPOSITORY}/archive/refs/tags/${MONGO_EXPRESS_TAG}.tar.gz -O /app/${MONGO_EXPRESS_TAG}.tar.gz \
-    && tar xzf /app/${MONGO_EXPRESS_TAG}.tar.gz --strip-components 1 \
-    && rm -f /app/${MONGO_EXPRESS_TAG}.tar.gz \
-    && chmod +x /docker-entrypoint.sh \
-    && apk -U add --no-cache \
+    yarn add mongo-express@${MONGO_EXPRESS_VERSION}; \
+    chmod +x /docker-entrypoint.sh; \
+    apk -U add --no-cache \
         bash \
         # grab tini for signal processing and zombie killing
-        tini \
-    && yarn install
-    # && yarn run build     # prepublish already run build
+        tini
+
+WORKDIR /node_modules/mongo-express
 
 EXPOSE 8081
 ENTRYPOINT [ "/sbin/tini", "--", "/docker-entrypoint.sh"]


### PR DESCRIPTION
Changes:
- replace the install of `mongo-expres` with _yarn_
- replace `&&` with `;` ([source](https://gitlab.com/gitlab-org/security-products/analyzers/bundler-audit/-/merge_requests/41#note_358023708))

Open points:
- I didn't included `--virtual .me-install-deps` option. Do we need it?

FYI @MahdiAbbasi95 