### PR TITLE
Refactor to avoid unnecessary multi-stage build

### DIFF
--- a/1.0/18-alpine3.17/Dockerfile
+++ b/1.0/18-alpine3.17/Dockerfile
@@ -6,29 +6,26 @@
 
 # https://nodejs.org/en/about/releases/
 # https://github.com/nodejs/Release#readme
-FROM node:18-alpine3.17 as builder
-
-ARG MONGO_EXPRESS_VERSION=release/v1.0.2
-
-RUN apk -U add git
-RUN git clone --depth 1 --branch $MONGO_EXPRESS_VERSION https://github.com/mongo-express/mongo-express.git /app
-WORKDIR /app
-
-RUN yarn install
-RUN yarn build
-
 FROM node:18-alpine3.17
 
-ARG MONGO_EXPRESS_VERSION=v1.0.2
-
 RUN set -eux; \
-    apk -U add --no-cache \
+    apk add --no-cache \
         bash \
         # grab tini for signal processing and zombie killing
         tini
 
-# Copy app from builder image
-COPY --from=builder /app /app
+WORKDIR /app
+
+ARG MONGO_EXPRESS_VERSION=release/v1.0.2
+
+RUN set -eux; \
+    apk add --no-cache --virtual .me-fetch-deps git; \
+    git clone --depth 1 --branch "$MONGO_EXPRESS_VERSION" -c advice.detachedHead=false https://github.com/mongo-express/mongo-express.git .; \
+    export DISABLE_V8_COMPILE_CACHE=1; \
+    yarn install; \
+    yarn build; \
+    apk del --no-network .me-fetch-deps; \
+    rm -rf .git* ~/.cache ~/.yarn
 
 # override some config defaults with values that will work better for docker
 ENV ME_CONFIG_MONGODB_URL="mongodb://mongo:27017" \
@@ -36,10 +33,7 @@ ENV ME_CONFIG_MONGODB_URL="mongodb://mongo:27017" \
     ME_CONFIG_SITE_SESSIONSECRET="secret" \
     VCAP_APP_HOST="0.0.0.0"
 
-WORKDIR /app
-
 EXPOSE 8081
 COPY docker-entrypoint.sh /
-RUN chmod +x /docker-entrypoint.sh
 ENTRYPOINT [ "/sbin/tini", "--", "/docker-entrypoint.sh"]
 CMD ["mongo-express"]

--- a/1.0/18-alpine3.18/Dockerfile
+++ b/1.0/18-alpine3.18/Dockerfile
@@ -6,29 +6,26 @@
 
 # https://nodejs.org/en/about/releases/
 # https://github.com/nodejs/Release#readme
-FROM node:18-alpine3.18 as builder
-
-ARG MONGO_EXPRESS_VERSION=release/v1.0.2
-
-RUN apk -U add git
-RUN git clone --depth 1 --branch $MONGO_EXPRESS_VERSION https://github.com/mongo-express/mongo-express.git /app
-WORKDIR /app
-
-RUN yarn install
-RUN yarn build
-
 FROM node:18-alpine3.18
 
-ARG MONGO_EXPRESS_VERSION=v1.0.2
-
 RUN set -eux; \
-    apk -U add --no-cache \
+    apk add --no-cache \
         bash \
         # grab tini for signal processing and zombie killing
         tini
 
-# Copy app from builder image
-COPY --from=builder /app /app
+WORKDIR /app
+
+ARG MONGO_EXPRESS_VERSION=release/v1.0.2
+
+RUN set -eux; \
+    apk add --no-cache --virtual .me-fetch-deps git; \
+    git clone --depth 1 --branch "$MONGO_EXPRESS_VERSION" -c advice.detachedHead=false https://github.com/mongo-express/mongo-express.git .; \
+    export DISABLE_V8_COMPILE_CACHE=1; \
+    yarn install; \
+    yarn build; \
+    apk del --no-network .me-fetch-deps; \
+    rm -rf .git* ~/.cache ~/.yarn
 
 # override some config defaults with values that will work better for docker
 ENV ME_CONFIG_MONGODB_URL="mongodb://mongo:27017" \
@@ -36,10 +33,7 @@ ENV ME_CONFIG_MONGODB_URL="mongodb://mongo:27017" \
     ME_CONFIG_SITE_SESSIONSECRET="secret" \
     VCAP_APP_HOST="0.0.0.0"
 
-WORKDIR /app
-
 EXPOSE 8081
 COPY docker-entrypoint.sh /
-RUN chmod +x /docker-entrypoint.sh
 ENTRYPOINT [ "/sbin/tini", "--", "/docker-entrypoint.sh"]
 CMD ["mongo-express"]

--- a/1.0/20-alpine3.17/Dockerfile
+++ b/1.0/20-alpine3.17/Dockerfile
@@ -6,29 +6,26 @@
 
 # https://nodejs.org/en/about/releases/
 # https://github.com/nodejs/Release#readme
-FROM node:20-alpine3.17 as builder
-
-ARG MONGO_EXPRESS_VERSION=release/v1.0.2
-
-RUN apk -U add git
-RUN git clone --depth 1 --branch $MONGO_EXPRESS_VERSION https://github.com/mongo-express/mongo-express.git /app
-WORKDIR /app
-
-RUN yarn install
-RUN yarn build
-
 FROM node:20-alpine3.17
 
-ARG MONGO_EXPRESS_VERSION=v1.0.2
-
 RUN set -eux; \
-    apk -U add --no-cache \
+    apk add --no-cache \
         bash \
         # grab tini for signal processing and zombie killing
         tini
 
-# Copy app from builder image
-COPY --from=builder /app /app
+WORKDIR /app
+
+ARG MONGO_EXPRESS_VERSION=release/v1.0.2
+
+RUN set -eux; \
+    apk add --no-cache --virtual .me-fetch-deps git; \
+    git clone --depth 1 --branch "$MONGO_EXPRESS_VERSION" -c advice.detachedHead=false https://github.com/mongo-express/mongo-express.git .; \
+    export DISABLE_V8_COMPILE_CACHE=1; \
+    yarn install; \
+    yarn build; \
+    apk del --no-network .me-fetch-deps; \
+    rm -rf .git* ~/.cache ~/.yarn
 
 # override some config defaults with values that will work better for docker
 ENV ME_CONFIG_MONGODB_URL="mongodb://mongo:27017" \
@@ -36,10 +33,7 @@ ENV ME_CONFIG_MONGODB_URL="mongodb://mongo:27017" \
     ME_CONFIG_SITE_SESSIONSECRET="secret" \
     VCAP_APP_HOST="0.0.0.0"
 
-WORKDIR /app
-
 EXPOSE 8081
 COPY docker-entrypoint.sh /
-RUN chmod +x /docker-entrypoint.sh
 ENTRYPOINT [ "/sbin/tini", "--", "/docker-entrypoint.sh"]
 CMD ["mongo-express"]

--- a/1.0/20-alpine3.18/Dockerfile
+++ b/1.0/20-alpine3.18/Dockerfile
@@ -6,29 +6,26 @@
 
 # https://nodejs.org/en/about/releases/
 # https://github.com/nodejs/Release#readme
-FROM node:20-alpine3.18 as builder
-
-ARG MONGO_EXPRESS_VERSION=release/v1.0.2
-
-RUN apk -U add git
-RUN git clone --depth 1 --branch $MONGO_EXPRESS_VERSION https://github.com/mongo-express/mongo-express.git /app
-WORKDIR /app
-
-RUN yarn install
-RUN yarn build
-
 FROM node:20-alpine3.18
 
-ARG MONGO_EXPRESS_VERSION=v1.0.2
-
 RUN set -eux; \
-    apk -U add --no-cache \
+    apk add --no-cache \
         bash \
         # grab tini for signal processing and zombie killing
         tini
 
-# Copy app from builder image
-COPY --from=builder /app /app
+WORKDIR /app
+
+ARG MONGO_EXPRESS_VERSION=release/v1.0.2
+
+RUN set -eux; \
+    apk add --no-cache --virtual .me-fetch-deps git; \
+    git clone --depth 1 --branch "$MONGO_EXPRESS_VERSION" -c advice.detachedHead=false https://github.com/mongo-express/mongo-express.git .; \
+    export DISABLE_V8_COMPILE_CACHE=1; \
+    yarn install; \
+    yarn build; \
+    apk del --no-network .me-fetch-deps; \
+    rm -rf .git* ~/.cache ~/.yarn
 
 # override some config defaults with values that will work better for docker
 ENV ME_CONFIG_MONGODB_URL="mongodb://mongo:27017" \
@@ -36,10 +33,7 @@ ENV ME_CONFIG_MONGODB_URL="mongodb://mongo:27017" \
     ME_CONFIG_SITE_SESSIONSECRET="secret" \
     VCAP_APP_HOST="0.0.0.0"
 
-WORKDIR /app
-
 EXPOSE 8081
 COPY docker-entrypoint.sh /
-RUN chmod +x /docker-entrypoint.sh
 ENTRYPOINT [ "/sbin/tini", "--", "/docker-entrypoint.sh"]
 CMD ["mongo-express"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,26 +1,25 @@
 # https://nodejs.org/en/about/releases/
 # https://github.com/nodejs/Release#readme
-FROM node:{{ env.variant }} as builder
-
-ARG MONGO_EXPRESS_VERSION=release/v{{ .version }}
-
-RUN apk -U add git
-RUN git clone --depth 1 --branch $MONGO_EXPRESS_VERSION https://github.com/mongo-express/mongo-express.git /app
-WORKDIR /app
-
-RUN yarn install
-RUN yarn build
-
 FROM node:{{ env.variant }}
 
 RUN set -eux; \
-    apk -U add --no-cache \
+    apk add --no-cache \
         bash \
         # grab tini for signal processing and zombie killing
         tini
 
-# Copy app from builder image
-COPY --from=builder /app /app
+WORKDIR /app
+
+ARG MONGO_EXPRESS_VERSION=release/v{{ .version }}
+
+RUN set -eux; \
+    apk add --no-cache --virtual .me-fetch-deps git; \
+    git clone --depth 1 --branch "$MONGO_EXPRESS_VERSION" -c advice.detachedHead=false https://github.com/mongo-express/mongo-express.git .; \
+    export DISABLE_V8_COMPILE_CACHE=1; \
+    yarn install; \
+    yarn build; \
+    apk del --no-network .me-fetch-deps; \
+    rm -rf .git* ~/.cache ~/.yarn
 
 # override some config defaults with values that will work better for docker
 ENV ME_CONFIG_MONGODB_URL="mongodb://mongo:27017" \
@@ -28,10 +27,7 @@ ENV ME_CONFIG_MONGODB_URL="mongodb://mongo:27017" \
     ME_CONFIG_SITE_SESSIONSECRET="secret" \
     VCAP_APP_HOST="0.0.0.0"
 
-WORKDIR /app
-
 EXPOSE 8081
 COPY docker-entrypoint.sh /
-RUN chmod +x /docker-entrypoint.sh
 ENTRYPOINT [ "/sbin/tini", "--", "/docker-entrypoint.sh"]
 CMD ["mongo-express"]


### PR DESCRIPTION
This takes advantage of `apk add --virtual` to install packages temporarily so they can be cleanly/easily removed after the build is complete.

It also cleans up / avoids extra files being created by Yarn / Node.js during build.